### PR TITLE
cpu and memory should be numbers

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -36,3 +36,13 @@ jobs:
     # Validate the files, referring only to the configuration and not accessing any remote services
     - name: Terraform Validate
       run: terraform -chdir=test validate
+
+    # Install Terraform 1.7, which is the earliest that supports `terraform test`.
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.7.5"
+
+      # Test
+    - name: Terraform Test
+      run: terraform -chdir=test test -verbose

--- a/test/bucket.tftest.hcl
+++ b/test/bucket.tftest.hcl
@@ -1,0 +1,16 @@
+mock_provider "aws" {
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::111111111111:role/test-role"
+    }
+  }
+  mock_resource "aws_ecs_task_definition" {
+    defaults = {
+      arn = "arn:aws:ecs:us-east-1:111111111111:task-definition/test-task-definition:1"
+    }
+  }
+}
+
+run "test" {
+  # module has no outputs to assert
+}

--- a/test/main.tf
+++ b/test/main.tf
@@ -8,10 +8,10 @@ module "minimal" {
   b2_application_key_arn    = ""
   b2_bucket                 = ""
   b2_path                   = ""
-  cpu                       = ""
+  cpu                       = 1
   ecs_cluster_id            = ""
   log_group_name            = ""
-  memory                    = ""
+  memory                    = 1
   rclone_arguments          = ""
   schedule                  = ""
   s3_bucket_name            = ""
@@ -27,10 +27,10 @@ module "full" {
   b2_application_key_arn    = ""
   b2_bucket                 = ""
   b2_path                   = ""
-  cpu                       = ""
+  cpu                       = 1
   ecs_cluster_id            = ""
   log_group_name            = ""
-  memory                    = ""
+  memory                    = 1
   rclone_arguments          = ""
   schedule                  = ""
   s3_bucket_name            = ""

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "b2_path" {
 
 variable "cpu" {
   description = "Amount of CPU to allocate to the task"
-  type        = string
+  type        = number
 }
 
 variable "ecs_cluster_id" {
@@ -45,7 +45,7 @@ variable "log_group_name" {
 
 variable "memory" {
   description = "Amount of memory to allocate to the task"
-  type        = string
+  type        = number
 }
 
 variable "rclone_arguments" {


### PR DESCRIPTION

### Fixed
- Change `cpu` and `memory` to number type to address error: "ECS Task Definition container_definitions is invalid: json: cannot unmarshal string into Go struct field ContainerDefinition.Cpu of type int32"