### PR TITLE
Fix authentication error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ locals {
         },
         {
           name  = "RCLONE_S3_ENV_AUTH"
-          value = true
+          value = "true"
         },
       ]
       secrets = [

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,10 @@ locals {
           name  = "RCLONE_ARGUMENTS"
           value = var.rclone_arguments
         },
+        {
+          name  = "RCLONE_S3_ENV_AUTH"
+          value = true
+        },
       ]
       secrets = [
         {

--- a/main.tf
+++ b/main.tf
@@ -148,13 +148,13 @@ resource "aws_iam_role_policy" "rclone_event_run_task_with_any_role" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = concat([
+    Statement = [
       {
         Effect = "Allow"
         Action = "iam:PassRole"
         Resource = [
           aws_iam_role.clone.arn,
-          aws_iam_role.rclone_event.arn,
+          aws_iam_role.ecs_task_execution_role.arn,
         ]
       },
       {
@@ -162,7 +162,7 @@ resource "aws_iam_role_policy" "rclone_event_run_task_with_any_role" {
         Action   = "ecs:RunTask"
         Resource = "${aws_ecs_task_definition.clone_cron_td.arn_without_revision}:*"
       }
-    ])
+    ]
   })
 }
 


### PR DESCRIPTION
[ITSE-2367](https://support.gtis.sil.org/issue/ITSE-2367) use IAM role in terraform-aws-sync-s3-to-b2

---

### Fixed
- Fixed an error in the event role policy that prevented the task from launching.
- Fixed authentication failure by instructing rclone to use AWS SDK authentication and ignore the static key values. This addresses the following error message:

> 2026/01/23 16:06:51 ERROR : S3 bucket redacted-bucket-name: error reading source root directory: operation error S3: ListObjectsV2, https response error StatusCode: 403, RequestID: GZX4NPS7D92A4YRF, HostID: 1/YhZs2rlqFsbgFxwHijodym6RiIcrFEWvIjx6eJFVhrgJFc1m4vQCpmr08z8Ib3vDZhtIM0lAM=, api error AccessDenied: Access Denied